### PR TITLE
Hype値の情報をクリップカードに表示する

### DIFF
--- a/cliphype/app/models.py
+++ b/cliphype/app/models.py
@@ -59,3 +59,4 @@ class AutoClip(models.Model):
     creator_id = models.CharField(max_length=128)
     creator_name = models.CharField(max_length=128)
     created_at = models.CharField(max_length=128)
+    hype = models.FloatField(blank=True, null=True)

--- a/cliphype/static/app/css/style.css
+++ b/cliphype/static/app/css/style.css
@@ -28,7 +28,7 @@
     margin-top: -18px;
     margin-left: -18px;
 }
-.text-title, .text-views, .text-date {
+.text-title, .text-views, .text-hype, .text-date {
     background-color: rgba(0,0,0,0.5);
 }
 .text-title {
@@ -36,6 +36,11 @@
 }
 .text-views {
     margin-left: -16px;
+    font-size: 14px;
+}
+.text-hype {
+    position: absolute;
+    margin-left: 44px;
     font-size: 14px;
 }
 .text-date {

--- a/cliphype/static/app/js/studio.js
+++ b/cliphype/static/app/js/studio.js
@@ -445,11 +445,11 @@ var app = new Vue({
         }
       });
       console.log(response);
+      let cont = response['data'];
       let clip_ids = [];
-      for(let i=0; i<response['data'].length; i++) {
-        clip_ids.push(response['data'][i]['clip_id']);
+      for(let i=0; i<cont.length; i++) {
+        clip_ids.push(cont[i]['clip_id']);
       }
-      var autoclips = [];
       var c = 50;
       var start = 0;
       while(start < clip_ids.length) {
@@ -464,11 +464,12 @@ var app = new Vue({
           data[i]['modal'] = false;
           data[i]['created_date'] = app.customformat(data[i]['created_at']);
           data[i]['created_epoch'] = app.getEpochTime(data[i]['created_at']);
-          autoclips.push(data[i]);
+          data[i]['hype'] = cont.find(el => el['clip_id'] == data[i]['id'])['hype'];
+          if (data[i]['hype']) data[i]['hype'] = data[i]['hype'].toFixed(2);
+          app.autoClips.push(data[i]);
         }
         start += c;
       }
-      app.autoClips = autoclips;
       app.autoClips.sort((a, b) => b['created_epoch'] - a['created_epoch']);
       this.clipsCurrentPage = 1;
    },

--- a/cliphype/templates/app/studio.html
+++ b/cliphype/templates/app/studio.html
@@ -190,6 +190,7 @@
                                     <div class="h-100 d-flex flex-column justify-content-end">
                                         <div class="d-flex justify-content-between">
                                             <div class="mb-1 text-white text-views rounded px-1 font-weight-bold">views:[[ item.view_count ]]</div>
+                                            <div v-show="item.hype" class="mb-1 text-white text-hype rounded px-1 font-weight-bold">hype:[[ item.hype ]]</div>
                                             <div class="mb-1 text-white text-date rounded px-1 font-weight-bold">[[ item.created_date ]]</div>
                                         </div>
                                     </div>


### PR DESCRIPTION
#78 

## 内容
- AutoClipモデルにhypeフィールドを追加
- クリップカードのviewsの隣にhypeを追加
- 小数点以下2桁目までを表示